### PR TITLE
Use english if no arabic

### DIFF
--- a/public/Content/access/health-system-overview.json
+++ b/public/Content/access/health-system-overview.json
@@ -1,11 +1,11 @@
 {
   "title": {
     "en": "Health System Overview",
-    "ar": "[Arabic]" 
+    "ar": "" 
   },
   "summary": {
     "en": "<p>Australia has universal healthcare access. This means Australian citizens and visitors who are eligible for Medicare benefits are entitled to free or subsidised health care at public hospitals and with certain doctors, known as general practitioners or GPs.</p>",
-    "ar": "[Arabic]" 
+    "ar": "" 
   },
   "topLevelVideo": "",
   "tab": [ ]

--- a/public/Content/family-planning/birth-spacing.json
+++ b/public/Content/family-planning/birth-spacing.json
@@ -1,11 +1,11 @@
 {
     "title": {
         "en": "Birth Spacing and Planning",
-        "ar": "[Arabic]"
+        "ar": ""
     },
     "summary": {
         "en": "<p>Planning and spacing pregnancies is beneficial for both you and your baby. It can reduce the risk of low birth weight (baby weighing less than 2.5kg), preterm birth (baby born prior to 37 weeks of pregnancy), uterine rupture, and mental health issues such as postpartum depression or stress. Additionally, if you are a breastfeeding mother, you can benefit from birth spacing which allows your body to replenish important nutrients such as folic acid and iron, while also strengthening your abdominal and pelvic floor muscles. Research indicates that spacing pregnancies by at least 18- 24 months is best.</p>",
-        "ar": "[Arabic]"
+        "ar": ""
     },
     "topLevelVideo": "https://www.youtube.com/embed/UpkltFvBAXI",
     "tab": []

--- a/public/Content/family-planning/contraception.json
+++ b/public/Content/family-planning/contraception.json
@@ -1,21 +1,21 @@
 {
   "title": {
     "en": "Contraception",
-    "ar": "[Arabic]"
+    "ar": ""
   },
   "summary": {
     "en": "<p>Contraception can help you avoid pregnancy resulting from unprotected sex. There are several methods of contraception that are safe, effective and easy to use prior to having sex such as condoms, pills, implants, injections, IUDs, diaphragms, vaginal rings, and natural methods.  Additionally, you may use emergency contraception up to 5 days after engaging in unprotected sex.</p>",
-    "ar": "[Arabic]"
+    "ar": ""
   },
   "topLevelVideo": "",
   "tab": [{
       "title": {
         "en": "Intra uterine device (IUD)",
-        "ar": "[Arabic]"
+        "ar": ""
       },
       "text": {
         "en": "<p>What is it: An IUD is a copper or hormone releasing device that is placed inside the uterus and creates an environment which ensures that pregnancy cannot happen. </p><p>How to use it: The IUD is inserted by a health practitioner and can stay in place for up to 10 years depending on which type is used. The IUD can be removed at any time by visiting your doctor.  </p><p>Efficacy: 99 per cent effective</p>",
-        "ar": "[Arabic]"
+        "ar": ""
       },
       "image": "",
       "video": "https://www.youtube.com/embed/pCXUUj4OVxw"
@@ -23,11 +23,11 @@
     {
       "title": {
         "en": "Condoms",
-        "ar": "[Arabic]"
+        "ar": ""
       },
       "text": {
         "en": "<p>What is it: Male and female condoms provide a barrier which prevents sperm from entering the uterus and fertilising an egg. Condoms can also reduce the risk of contracting sexually transmitted infections, including HIV.</p><p>How to use it:<ul><li>How to use it: Male condom- the male condom is put over the erect penis and should be used every time you have sex.</li><li>Female condom-  The female condom which is stronger than the male latex condom sits in the vagina using the flexible ring. You can order female condoms from Family Planning Victoria, retail stores, or health clinics.</li></ul></p><p>Efficacy:<ul><li>Male condom- 98 per cent effective when used correctly</li><li>Female condom- 95 per cent effective when used correctly </li></ul></p>",
-        "ar": "[Arabic]"
+        "ar": ""
       },
       "image": "",
       "video": "https://www.youtube.com/embed/-NbpQv3dJ1c"
@@ -35,11 +35,11 @@
     {
       "title": {
         "en": "Pills",
-        "ar": "[Arabic]"
+        "ar": ""
       },
       "text": {
         "en": "<p>What is it: Contraceptive pills prevent pregnancy by using synthetic forms of hormones.  </p>  <p>How to use it: Contraceptive pills are available with a doctor’s prescription and should be taken orally every day at the same time. </p> <p>Efficacy: 99 per cent effective when used correctly. </p>",
-        "ar": "[Arabic]"
+        "ar": ""
       },
       "image": "https://3.bp.blogspot.com/-jrvYC131CYY/V4mwbPWJZpI/AAAAAAAAAzg/FIiKH2vrAjcEVx6tS3mu4NRfUAuy6P9RwCLcB/s1600/xxxx.png",
       "video": "https://www.youtube.com/embed/67Xvbahh8Is"
@@ -47,11 +47,11 @@
     {
       "title": {
         "en": "Injection",
-        "ar": "[Arabic]"
+        "ar": ""
       },
       "text": {
         "en": "<p>What is it: The injection (Depo) is a hormonal injection which stops ovulation and makes the fluid at the opening to the uterus thicker, which prevents sperm from entering.</p>  <p>How to use it: The injection is administered by a health practitioner every 12 to 14 weeks. </p> <p>Efficacy: 94 per cent effective </p>",
-        "ar": "[Arabic]"
+        "ar": ""
       },
       "image": "",
       "video": "https://www.youtube.com/embed/93VgngakeMU"
@@ -59,11 +59,11 @@
     {
       "title": {
         "en": "Implants",
-        "ar": "[Arabic]"
+        "ar": ""
       },
       "text": {
         "en": "<p>What is it: The implant is a hormonal device that is placed on the upper arm under the skin. It is a good option for women who cannot take synthetic oestrogens. </p>  <p>How to use it: The implant is inserted by a health practitioner and can be left in place for up to three years. </p> <p>Efficacy: 99 per cent effective </p>",
-        "ar": "[Arabic]"
+        "ar": ""
       },
       "image": "",
       "video": "https://www.youtube.com/embed/4RBnQKPbBy4"
@@ -71,11 +71,11 @@
     {
       "title": {
         "en": "Vaginal rings",
-        "ar": "[Arabic]"
+        "ar": ""
       },
       "text": {
         "en": "<p>What is it: The vaginal ring is put into the vagina and slowly releases hormones which prevent pregnancy.  </p>  <p>How to use it: The ring can easily be inserted at home. After three weeks, it should be removed and replaced one week later.  </p> <p>Efficacy: 99 per cent effective if used correctly. </p>",
-        "ar": "[Arabic]"
+        "ar": ""
       },
       "image": "",
       "video": "https://www.youtube.com/embed/JFjD9vSNdC8"
@@ -83,11 +83,11 @@
     {
       "title": {
         "en": "Diaphragms",
-        "ar": "[Arabic]"
+        "ar": ""
       },
       "text": {
         "en": "<p>What is it: The diaphragm is a soft dome that is fitted in the vagina providing a barrier from the uterus. </p>  <p>How to use it: The diaphragm should be fitted by a health practitioner and should remain in the vagina for up to 6 hours after having sex. This barrier method does not protect from sexually transmitted infections.  </p> <p>Efficacy: 94 per cent effective when used correctly.  </p>",
-        "ar": "[Arabic]"
+        "ar": ""
       },
       "image": "",
       "video": ""
@@ -95,11 +95,11 @@
     {
       "title": {
         "en": "Emergency contraception",
-        "ar": "[Arabic]"
+        "ar": ""
       },
       "text": {
         "en": "<p>What is it: Emergency contraception is also known as “the morning after pill.” This pill can stop ovulation and can be taken to prevent pregnancy if you had unprotected sex or if the condom malfunctions. </p>  <p>How to use it: You can purchase this pill from most pharmacies. Although you should take it as soon as possible, it can be effective up to 96 hours after having sex.   </p> <p>Efficacy: This method will not be very effective if used after 96 hours after having sex. </p>",
-        "ar": "[Arabic]"
+        "ar": ""
       },
       "image": "",
       "video": "https://www.youtube.com/embed/YGc92_b0lbk?list=PL_0c66FsSFAIevxnol1LzZxigrwTwPJhf"
@@ -107,11 +107,11 @@
     {
       "title": {
         "en": "Natural methods",
-        "ar": "[Arabic]"
+        "ar": ""
       },
       "text": {
         "en": "<p>What is it: Natural methods including temperature method, rhythm method, or cervical mucus method help you track the days which you are ovulating, which is when you have the highest chance of getting pregnant. You can avoid pregnancy by not having sex on those days. While natural methods are free and don’t involve any devices or medication, they are only effective when used correctly. </p>  <p>How to use it: Temperature method: Take your temperature every morning when you wake up. When you ovulate, your temperature can increase by almost 1 degree F, which can let you know when to avoid having sex.</p> <p>Rhythm method: Before you start, track your period of 6- 12 months, then use the following formula:<ul> <li>Subtract 18 from the number of days in your shortest cycle.</li> <li>Count that many days after you start your period. That’s your first fertile day.</li> <li>Subtract 11 from the number of days in your longest cycle.</li> <li>Count that many days from the start of your period. That’s your last fertile day.</li> <li>Don’t have sex on or between your first and last fertile days.</li> </ul>  </p> <p>Cervical mucus method:  When you are ovulating, you may have more cervical mucus than other times of the month, such as right after your period. You may also notice changes in color and texture which can signal that you are ovulating. When you are ovulating, your cervical mucus can look clear and stretch similar to egg whites. This can help you know when to avoid sex. </p><p>Efficacy- Natural methods can have up to a 24 per cent chance of leading to pregnancy when not used correctly. If your cycle is irregular, you might consult your health practitioner about your other options. </p>",
-        "ar": "[Arabic]"
+        "ar": ""
       },
       "image": "",
       "video": "https://www.youtube.com/embed/4RBnQKPbBy4"

--- a/src/components/content-page-container/ContentPageContainer.js
+++ b/src/components/content-page-container/ContentPageContainer.js
@@ -13,6 +13,7 @@ class ContentPageContainer extends Component {
       data: this.getData()
     }
     this.getTabs = this.getTabs.bind(this)
+    this.getLocalisedData = this.getLocalisedData.bind(this)
   }
   
   getData() {
@@ -24,18 +25,23 @@ class ContentPageContainer extends Component {
         })
       })
   }
+
+  getLocalisedData(data) {
+    const lang = this.props.lang
+    const localisedData = data[lang] ? data[lang] : data['en']
+    return localisedData
+  }
   
   getTabs() {
-    var lang = this.props.lang
     var data = this.state.data.tab
     return data.map(item => ({
       tabClassName: 'tab',
       panelClassName: 'panel',
-      title: item.title[lang],
+      title: this.getLocalisedData(item.title),
       getContent: () => {
         return (
           <div>
-            <div className='tabContent' dangerouslySetInnerHTML={{__html: item.text[lang]}} />
+            <div className='tabContent' dangerouslySetInnerHTML={{__html: this.getLocalisedData(item.text)}} />
             {item.video && <Video url={item.video} />}
             <div className='tabLinks'>
               {item.links && item.links.length > 0 && <Links links={item.links} />}
@@ -54,12 +60,12 @@ class ContentPageContainer extends Component {
     }
     return (
       <div style={style} className={'wrapper'}>
-        <h1 className="content-page-title">{data && data.title[lang]}</h1>
-        {data && <div className='summary' dangerouslySetInnerHTML={{__html: data.summary[lang]}} />}
+        <h1 className="content-page-title">{data && this.getLocalisedData(data.title)}</h1>
+        {data && <div className='summary' dangerouslySetInnerHTML={{__html: this.getLocalisedData(data.summary)}} />}
         {data && data.topLevelVideo && <Video url={data.topLevelVideo} />}
         {data && data.topLevelVideo && data.tab && <br/>}
         {data && data.tab && <Tabs items={this.getTabs()} />}
-        {data && data.notes && <div className='notes' dangerouslySetInnerHTML={{__html: data.notes[lang]}} />}
+        {data && data.notes && <div className='notes' dangerouslySetInnerHTML={{__html: this.getLocalisedData(data.notes)}} />}
       </div>
     )
   }

--- a/src/components/navmenu/NavMenu.js
+++ b/src/components/navmenu/NavMenu.js
@@ -59,7 +59,7 @@ class NavMenu extends Component {
           icon: iconClinics,
           name: {
             en: 'Clinic Locations',
-            ar: '[Arabic] Clinic Locations'
+            ar: ' Clinic Locations'
           },
           url: '/clinics'
         },


### PR DESCRIPTION
If Arabic is selected while browsing a page with no Arabic content, we display the English content rather than the [Arabic] placeholder